### PR TITLE
修复了 子序列问题模版 中的计算条件

### DIFF
--- a/动态规划系列/子序列问题模板.md
+++ b/动态规划系列/子序列问题模板.md
@@ -41,8 +41,8 @@ int[][] dp = new dp[n][n];
 
 for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
-        if (arr[i] == arr[j]) 
-            dp[i][j] = dp[i][j] + ...
+        if (arr[i] == arr[j])
+            dp[i][j] = dp[i - 1][j - 1] + ...
         else
             dp[i][j] = 最值(...)
     }


### PR DESCRIPTION
二维dp问题中应该是`dp[i][j] = dp[i - 1][j - 1] + ...`, 而不是 `dp[i][j] = dp[i][j] + ...`