### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This command specifies the `english` branch and limit the depth of clone, get ri
 # Table of Content
 
 * I. Dynamic Programming
-  * [Dynamic Programming in Detials](dynamic_programming/AnalysisOfDynamicProgramming.md)
+  * [Dynamic Programming in Details](dynamic_programming/AnalysisOfDynamicProgramming.md)
   * [Classic DP: Edit Distance](dynamic_programming/EditDistance.md)
   * [Classic DP: Super Egg](dynamic_programming/ThrowingEggsinHighBuildings.md)
   * [Classic DP: Super Egg(Advanced Solution)](dynamic_programming/SuperEggDropAdvanced.md)


### PR DESCRIPTION
In the README.md, a 'Detail` was spelled 'Detial'