### PR TITLE
二分查找判定子序列 C++版本

### DIFF
--- a/高频面试系列/二分查找判定子序列.md
+++ b/高频面试系列/二分查找判定子序列.md
@@ -142,6 +142,37 @@ boolean isSubsequence(String s, String t) {
 
 ![labuladong](../pictures/labuladong.jpg)
 
+[yuxiang-zhang](https://github.com/yuxiang-zhang) 提供 C++ 代码：
+
+```cpp
+    #define ASCII_COUNT 256
+    using std::vector;
+    bool isSubsequence(string s, string t) {
+
+        int m = s.length(), n = t.length();
+        
+        // 对 t 进行预处理
+        vector<vector<int>> index(ASCII_COUNT);
+        for(int i = 0; i < n; ++i) {
+            char c = t[i];
+            index[c].emplace_back(i);
+        }
+        
+        // 借助 index 查找 s[i]
+        for(int i = 0, j = 0; i < m; ++i) {
+            char c = s[i];
+            // 整个 t 压根儿没有字符 c
+            if(index[c].empty()) return false;
+            
+            int pos = std::lower_bound(index[c].begin(), index[c].end(), j) - index[c].begin();
+            // 二分搜索区间中没有找到字符 c
+            if(pos == index[c].size()) return false;
+            // 向前移动指针 j
+            j = index[c][pos] + 1;
+        }
+        return true;
+    }
+```
 
 [上一篇：一行代码就能解决的算法题](../高频面试系列/一行代码解决的智力题.md)
 


### PR DESCRIPTION
#301 为二分查找判定子序列添加C++版本
完全参照原Java解法

运行结果，加了`static int __=[](){std::ios::sync_with_stdio(false);return 0;}();`语句（禁用cin和stdin同步的兼容性）后：
![image](https://user-images.githubusercontent.com/23327251/85479053-6c489880-b58b-11ea-921e-153626c01cf6.png)