### PR TITLE
[english] Sync Table of Contents with master/Chinese branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 English translation is in progress... Some articles are still in Chinese, but most are completed. Please **star** this repo. The full translation will eventually be finished. Enjoy.
 
-These articles go over different kinds of **Algorithmic Thinking**. All are based on LeetCode problems. They are **not only the solution code for the problem, but also WHY the solution works and HOW we can figure it out**.
+These articles go over different kinds of **Algorithmic Thinking**. All are based on LeetCode problems. They contain **not just the solution code for a problem, but also WHY the solution works and HOW you too can figure it out**.
 
 I don't like one-liners. They can be confusing. I like clear, easily understandable code.
 
 The **Gitbook** has been deployed and will sync with this branch of the repo: [https://labuladong.gitbook.io/algo-en/](https://labuladong.gitbook.io/algo-en/)
 
-If you want to clone this repo, please use following command:
+If you would like to clone this repo, please use following command:
 
 ```shell
 git clone --depth 1  --branch english https://github.com/labuladong/fucking-algorithm.git
@@ -18,79 +18,90 @@ This command specifies the `english` branch and will limit the depth of the clon
 
 ## Table of Contents
 
-* I. Dynamic Programming
+* 0 . Must Read Series
+  * [The Framework for Learning Algorithms and intense problem solving exercises](think_like_computer/Framework%20and%20thoughts%20about%20learning%20data%20structure%20and%20algorithm.md)
+  * [Algs4: Recommended book for Learning Algorithms and Data Structures](think_like_computer/why_i_recommend_algs4.md)
+  * [An analysis of Dynamic Programming](dynamic_programming/AnalysisOfDynamicProgramming.md)
+  * [Dynamic Programming Q&A - What is Optimal Substructure](dynamic_programming/OptimalSubstructure.md)
+  * [The Framework for Backtracking Algorithm](think_like_computer/DetailsaboutBacktracking.md)
+  * [Binary Search in Detail: I wrote a Poem](think_like_computer/DetailedBinarySearch.md)
+  * [The Sliding Window Technique](think_like_computer/SlidingWindowTechnique.md)
+  * [Difference Between Process and Thread in Linux](common_knowledge/linuxProcess.md)
+  * [Some Good Online Practice Platforms](common_knowledge/OnlinePraticePlatform.md)
+
+* I. Dynamic Programming Series
   * [Dynamic Programming in Details](dynamic_programming/AnalysisOfDynamicProgramming.md)
+  * [Dynamic Programming Q&A - What is Optimal Substructure](dynamic_programming/OptimalSubstructure.md)
+  * [Classic DP: Longest Common Subsequence](dynamic_programming/LongestCommonSubsequence.md)
   * [Classic DP: Edit Distance](dynamic_programming/EditDistance.md)
   * [Classic DP: Super Egg](dynamic_programming/ThrowingEggsinHighBuildings.md)
-  * [Classic DP: Super Egg(Advanced Solution)](dynamic_programming/SuperEggDropAdvanced.md)
-  * [Class DP: Longest Common Subsequence](dynamic_programming/LongestCommonSubsequence.md)
-  * [Classis DP: Game Problems](dynamic_programming/GameProblemsInDynamicProgramming.md)
-  * [Regular Expression](dynamic_programming/RegularExpression.md)
+  * [Classic DP: Super Egg (Advanced Solution)](dynamic_programming/SuperEggDropAdvanced.md)
   * [The Strategies of Subsequence Problem](dynamic_programming/StrategiesForSubsequenceProblem.md)
+  * [Classic DP: Game Problems](dynamic_programming/GameProblemsInDynamicProgramming.md)
   * [Greedy: Interval Scheduling](dynamic_programming/IntervalScheduling.md)
-  * [4 Keys Keyboard](dynamic_programming/FourKeysKeyboard.md)
-  * [What is DP Optimal Substructure](dynamic_programming/OptimalSubstructure.md)
-  * [Longest Increasing Subsequence](dynamic_programming/LongestIncreasingSubsequence.md)
   * [KMP Algorithm In Detail](dynamic_programming/KMPCharacterMatchingAlgorithmInDynamicProgramming.md)
-  * [House Robber Problems](dynamic_programming/HouseRobber.md)
-  * [Stock Buy and Sell Problems](dynamic_programming/BestTimeToBuyAndSellStock.md)
-
-* II. Data Structures
-  * [Binary Head and Priority Queue](data_structure/binary_heap_implements_priority_queues.md)
+  * [A solution to all Buy Time to Buy and Sell Stock Problems](dynamic_programming/BestTimeToBuyAndSellStock.md)
+  * [A solution to all House Robber Problems](dynamic_programming/HouseRobber.md)
+  * [4 Keys Keyboard](dynamic_programming/FourKeysKeyboard.md)
+  * [Regular Expression](dynamic_programming/RegularExpression.md)
+  * [Longest Increasing Subsequence](dynamic_programming/LongestIncreasingSubsequence.md)
+  
+* II. Data Structures Series
+  * [The Framework for Learning Algorithms and intense problem solving exercises](think_like_computer/Framework%20and%20thoughts%20about%20learning%20data%20structure%20and%20algorithm.md)
+  * [Algs4: Recommended book for Learning Algorithms and Data Structures](think_like_computer/why_i_recommend_algs4.md)
+  * [Binary Heap and Priority Queue](data_structure/binary_heap_implements_priority_queues.md)
   * [LRU Cache Strategy in Detail](interview/LRU_algorithm.md)
   * [Collections of Binary Search Operations](data_structure/The_Manipulation_Collection_of_Binary_Search_Tree.md)
   * [Special Data Structure: Monotonic Stack](data_structure/MonotonicStack.md)
   * [Special Data Structure: Monotonic Stack](data_structure/Monotonic_queue.md)
   * [Design Twitter](data_structure/design_Twitter.md)
   * [Reverse Part of Linked List via Recursion](data_structure/reverse_part_of_a_linked_list_via_recursion.md)
-  * [What's the Best Algo Book](think_like_computer/why_i_recommend_algs4.md)
   * [Queue Implement Stack/Stack implement Queue](data_structure/ImplementQueueUsingStacksImplementStackUsingQueues.md)
-  * [Frameworkabout learning data structure and algorithm](think_like_computer/Framework%20and%20thoughts%20about%20learning%20data%20structure%20and%20algorithm.md)
-
-* III. Algorithmic thinking
+  
+* III. Algorithmic Thinking Series
   * [My Way to Learn Algorithm](think_like_computer/ThewaytoAlgorithmlearning.md)
-  * [The Framwork of Backtracking Algorithm](think_like_computer/DetailsaboutBacktracking.md)
+  * [The Framework of Backtracking Algorithm](think_like_computer/DetailsaboutBacktracking.md)
   * [Binary Search in Detail](think_like_computer/DetailedBinarySearch.md)
-  * [The Tech of Double Pointer](think_like_computer/double_pointer.md)
-  * [The Key Concept of TowSum Problems](think_like_computer/The_key_to_resolving_TwoSum_problems.md)
-  * [Divide Complicated Problem: Implement a Calculator](data_structure/Implementing_the_functions_of_a_calculator.md)
-  * [Prefix Sum Skill](think_like_computer/prefix_sum.md)
+  * [Backtracking Solve Subset/Permutation/Combination](interview/Subset_Permutation_Combination.md)
+  * [Diving into the technical parts of Double Pointers](think_like_computer/double_pointer.md)
+  * [Sliding Window Technique](think_like_computer/SlidingWindowTechnique.md)
+  * [The Core Concept of TwoSum Problems](think_like_computer/The_key_to_resolving_TwoSum_problems.md)
+  * [Common Bit Manipulations](think_like_computer/CommonBitManipulation.md)
+  * [Breaking down a Complicated Problem: Implement a Calculator](data_structure/Implementing_the_functions_of_a_calculator.md)
+  * [Pancake Sorting Algorithm](think_like_computer/PancakesSorting.md)
+  * [Prefix Sum: Intro and Concept](think_like_computer/prefix_sum.md)
+  * [String Multiplication](think_like_computer/string_multiplication.md)
   * [FloodFill Algorithm in Detail](think_like_computer/flood_fill.md)
   * [Interval Scheduling: Interval Merging](think_like_computer/IntervalMerging.md)
   * [Interval Scheduling: Intersections of Intervals](think_like_computer/IntervalIntersection.md)
-  * [String Multiplication](think_like_computer/string_multiplication.md)
-  * [Pancake Sorting Algorithm](think_like_computer/PancakesSorting.md)
-  * [Sliding Window Algorithm](think_like_computer/SlidingWindowTechnique.md)
-  * [Some Useful Bit Manipulations](think_like_computer/CommonBitManipulation.md)
   * [Russian Doll Envelopes Problem](think_like_computer/RussianDollEnvelopes.md)
-  * [Recursion In Detail](data_structure/RecursionInDetail.md)
-  * [Backtracking Solve Subset/Permutation/Combination](interview/Subset_Permutation_Combination.md)
-  * [Several counter-intuitive Probability Problems](think_like_computer/several_counter_intuitive_probability_problems.md)
+  * [A collection of counter-intuitive Probability Problems](think_like_computer/several_counter_intuitive_probability_problems.md)
   * [Shuffle Algorithm](think_like_computer/Shuffle_Algorithm.md)
-
-* IV. High Frequency Interview Problems
+  * [Recursion In Detail](data_structure/RecursionInDetail.md)
+  
+* IV. High Frequency Interview Series
   * [How to Implement LRU Cache](interview/LRU_algorithm.md)
   * [How to Find Prime Number Efficiently](interview/Print_PrimeNumbers.md)
   * [How to Calculate Minimium Edit Distance](dynamic_programming/EditDistance.md)
-  * [How to Solve Drop Water Problem](interview/Trapping_Rain_Water.md)
-  * [How to Remove Duplicate From Sorted Sequence](interview/RemoveDuplicatesfromSortedArray.md)
+  * [How to use Binary Search](interview/UsingBinarySearchAlgorithm.md)
+  * [How to efficiently solve Trapping Rain Water Problem](interview/Trapping_Rain_Water.md)
+  * [How to Remove Duplicates From Sorted Array](interview/RemoveDuplicatesfromSortedArray.md)
   * [How to Find Longest Palindromic Substring](interview/TheLongestPalindromicSubstring.md)
   * [How to Reverse Linked List in K Group](interview/reverse-nodes-in-k-group.md)
   * [How to Check the Validation of Parenthesis](interview/valid-parentheses.md)
   * [How to Find Missing Element](interview/missing_elements.md)
-  * [How to Pick Elements From a Arbitrary Sequence](interview/ReservoirSampling.md)
-  * [How to use Binary Search](interview/UsingBinarySearchAlgorithm.md)
-  * [How to Scheduling Seats](interview/Seatscheduling.md)
+  * [How to Find Duplicates and Missing Elements](interview/Find-Duplicate-and-Missing-Element.md)
+  * [How to Check Palindromic LinkedList](interview/check_palindromic_linkedlist.md)
+  * [How to Pick Elements From an Infinite Arbitrary Sequence](interview/ReservoirSampling.md)
+  * [How to Schedule Seats for Students](interview/Seatscheduling.md)
   * [Union-Find Algorithm in Detail](think_like_computer/Union-find-Explanation.md)
   * [Union-Find Application](think_like_computer/Union-Find-Application.md)
-  * [Find Sebesquence With Binary Search](interview/findSebesquenceWithBinarySearch.md)
-  * [Problems can be sloved by one line](interview/one-line-code-puzzles.md)
-  * [How to Find Dup and Missing Element](interview/Find-Duplicate-and-Missing-Element.md)
-  * [How to Check Palindrom LinkedList](interview/check_palindromic_linkedlist.md)
+  * [Problems that can be solved in one line](interview/one-line-code-puzzles.md)
+  * [Find Subsequence With Binary Search](interview/findSebesquenceWithBinarySearch.md)
 
 * V. Common Knowledge
   * [Difference Between Process and Thread in Linux](common_knowledge/linuxProcess.md)
-  * [You Must Know About Linux Shell](common_knowledge/linuxshell.md)
-  * [You Must Know About Cookie and Session](common_knowledge/SessionAndCookie.md)
+  * [This is the only article you need to understand `session` and `cookie`](common_knowledge/SessionAndCookie.md)
+  * [Knowledge about Linux Shell that you should know](common_knowledge/linuxshell.md)
   * [Cryptology Algorithm](common_knowledge/Cryptology.md)
-  * [Some Good Online Pratice Platforms](common_knowledge/OnlinePraticePlatform.md)
+  * [Git/SQL/Good Online Practice Platforms](common_knowledge/OnlinePraticePlatform.md)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This command specifies the `english` branch and will limit the depth of the clon
 
 * V. Common Knowledge
   * [Difference Between Process and Thread in Linux](common_knowledge/linuxProcess.md)
-  * [This is the only article you need to understand `session` and `cookie`](common_knowledge/SessionAndCookie.md)
-  * [Knowledge about Linux Shell that you should know](common_knowledge/linuxshell.md)
+  * [You Must Know About Linux Shell](common_knowledge/linuxshell.md)
+  * [You Must Know About Cookie and Session](common_knowledge/SessionAndCookie.md)
   * [Cryptology Algorithm](common_knowledge/Cryptology.md)
-  * [Git/SQL/Good Online Practice Platforms](common_knowledge/OnlinePraticePlatform.md)
+  * [Some Good Online Practice Platforms](common_knowledge/OnlinePraticePlatform.md)


### PR DESCRIPTION
我已阅读过[翻译组工作流程](https://github.com/labuladong/fucking-algorithm/issues/9)，我已阅读过[翻译要求](https://github.com/labuladong/fucking-algorithm/blob/english/README.md)，我已查看 [已完成列表](https://github.com/labuladong/fucking-algorithm/pulls?q=is%3Apr+is%3Aclosed)，确保我要翻译的文章还没有被翻译。

我将开始翻译如下文章（点击可查看目标文章）：

<!-- 此处修改为你选择的文章名字和 url -->
[README.md](https://github.com/labuladong/fucking-algorithm/master/README.md)

我对如何翻译此文章已经心中有数，我准备将它翻译成：**英文**

主仓库, 本来是想开始翻译第零系列的， 但开工的时候发现到 `算法思维系列/学习数据结构和算法的高效方法.md` 已经翻译了，而且第零章列出来的也在其他系列显示。

我看了[raw README.md](https://raw.githubusercontent.com/labuladong/fucking-algorithm/master/README.md) 分析了中文和英文的文件名变同步了一下。 我个人英文比中文好，感觉目录没有同步到比较难跟着中文版的思路去参考 。也顺便修改了语法和typo. 

感谢开发这个resource, 希望我接下来参考也可以进步英文的翻译，至于中文到英文和学习算法题方面， 请多指教！