### PR TITLE
fix: typo of nohup

### DIFF
--- a/common_knowledge/linuxshell.md
+++ b/common_knowledge/linuxshell.md
@@ -91,10 +91,10 @@ Nevertheless, commands like `(cmd &)` move the process under `systemd`, an OS gu
 An alternative approach to background execution is:
 
 ```shell
-$ nohub some_cmd &
+$ nohup some_cmd &
 ```
 
-`nohub` functions similarly, but with extensive testing, `(cmd &)` appears to be more stable.
+`nohup` functions similarly, but with extensive testing, `(cmd &)` appears to be more stable.
 
 ### 3. Single-quotes vs. double-quotes
 


### PR DESCRIPTION
fixes #443

1. 'nohup' was misspelled as 'nohub'