### PR TITLE
修复 Comparator 的 compare 方法里的溢出问题

### DIFF
--- a/动态规划系列/贪心算法之区间调度问题.md
+++ b/动态规划系列/贪心算法之区间调度问题.md
@@ -72,9 +72,15 @@ int intervalSchedule(int[][] intvs) {}
 public int intervalSchedule(int[][] intvs) {
     if (intvs.length == 0) return 0;
     // 按 end 升序排序
-    Arrays.sort(intvs, new Comparator<int[]>() {
+    Arrays.sort(points, new Comparator<int[]>() {
+        @Override
         public int compare(int[] a, int[] b) {
-            return a[1] - b[1];
+            // 这里不能使用 a[1] - b[1]，要注意溢出问题
+            if (a[1] < b[1])
+                return -1;
+            else if (a[1] > b[1])
+                return 1;
+            else return 0;
         }
     });
     // 至少有一个区间不相交

--- a/动态规划系列/贪心算法之区间调度问题.md
+++ b/动态规划系列/贪心算法之区间调度问题.md
@@ -72,7 +72,7 @@ int intervalSchedule(int[][] intvs) {}
 public int intervalSchedule(int[][] intvs) {
     if (intvs.length == 0) return 0;
     // 按 end 升序排序
-    Arrays.sort(points, new Comparator<int[]>() {
+    Arrays.sort(intvs, new Comparator<int[]>() {
         @Override
         public int compare(int[] a, int[] b) {
             // 这里不能使用 a[1] - b[1]，要注意溢出问题


### PR DESCRIPTION
在 compare 方法里，不能直接使用 a[1] - b[1]，因为可能会溢出，目前这种写法在 leetcode 452 已经不能通过了。
我参考 JDK 里的 Integer.compare 方法，修改了一下，已经可以通过  leetcode 452 的所有用例。