### PR TITLE
Update 动态规划之正则表达.md

### DIFF
--- a/动态规划系列/动态规划之正则表达.md
+++ b/动态规划系列/动态规划之正则表达.md
@@ -60,6 +60,23 @@ bool isMatch(string s, string p) {
     }
     return i == j;
 }
+//不考虑 `*` 通配符
+//这里是有bug的，比如s=”ab" p ="aba" 你的结果是true
+//    static boolean isMatch(String s, String p) {
+//        int lenS = s.length();
+//        int lenP = p.length();
+//        if (lenP != lenS){
+//            return false;
+//        }
+//        int i=0;
+//        while (i<lenS){
+//            if (s.charAt(i)!= p.charAt(i) && p.charAt(i)!='.'){
+//                return false;
+//            }
+//            i++;
+//        }
+//        return true;
+//    }
 ```
 
 那么考虑一下，如果加入 `*` 通配符，局面就会稍微复杂一些，不过只要分情况来分析，也不难理解。


### PR DESCRIPTION
不考虑 `*` 通配符,判断相等有bug