### PR TITLE
Update 动态规划详解进阶.md

### DIFF
--- a/动态规划系列/动态规划详解进阶.md
+++ b/动态规划系列/动态规划详解进阶.md
@@ -575,7 +575,7 @@ var coinChange = function (coins, amount) {
         // 内层 for 循环在求所有选择的最小值
         for (let coin of coins) {
             // 子问题无解，跳过
-            if (i - coin < 0) continue;
+            if (i - coin < 0 || dp[i-coin] === i - count + 1) continue;
             dp[i] = Math.min(dp[i], 1 + dp[i - coin]);
         }
     }


### PR DESCRIPTION
子問題無解包含了 (1) 硬幣 < 0 與 (2) dp[硬幣] == 硬幣+1，兩個條件。
否則下面一行計算 `1 + dp[i - coin]` 就顯得無意義

例如硬幣數值只有2元，要計算 3元的最少硬幣數
0元 -> 0
1元 -> -1
2元 -> 1
3元 -> -1

若在1元時，因為子問題無解跳過，計算3元時，又會回到1元的解，此時的解再加1 (2 +1 = 3)，但是3元的解是-1而不是3。