### PR TITLE
创建 .gitattributes, 这波是强迫症狂喜

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
这个.gitattributes文件可以让GitHub的语言统计将.md文件识别为Markdown语言。
![image](https://user-images.githubusercontent.com/75297777/145145989-420fa159-9064-495e-838c-1cc913ede43e.png)