### PR TITLE
fix the javascript and python version solution of "group-anagrams"(字母异位词的分组)

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -27725,7 +27725,7 @@ function encode(s) {
         let delta = c.charCodeAt() - 'a'.charCodeAt();
         count[delta]++;
     }
-    return count.join('');
+    return count.toString();
 }
 ```
 
@@ -27756,7 +27756,7 @@ class Solution:
         for c in s:
             delta = ord(c) - ord('a')
             count[delta] += 1
-        return ''.join(str(x) for x in count)
+        return str(count)
 ```
 
 https://leetcode.cn/problems/group-anagrams 的多语言解法👆


### PR DESCRIPTION
<!-- 
如果你是在修复刷题插件的解法代码，请遵循正确的格式，具体要求参见如下链接：

https://github.com/labuladong/fucking-algorithm/issues/1113
-->

<!-- 如果你的 PR 能够关闭某个 issue，那么在 Fixes 关键词后面输入该 issue 的链接 -->

Fixes <!-- issue 链接 -->

我修改的是如下题目的 javascript和python 解法：
https://leetcode.cn/problems/group-anagrams

思路说明：Chatgpt在翻译这两个语言的代码时，encode()函数在最后返回count时，没有正确地把count数组转为string，而是把count的每一位先变为int，再用join()连接起来

这样的做法会导致一些错误，如：
{ 'a' : 1, 'b' : 0 } ——> 10 ; { 'a' : 0, 'b' : 10 } ——> 10，
从而错误地把一些字符串分为一组

而正确的做法是用javascript的toString()及python的str()进行转换

<!-- 这里放对应题目的链接，方便验证代码 -->

通过截图如下：
![image](https://user-images.githubusercontent.com/116165769/227757319-43228549-b85c-4ff1-a071-3f1258458c45.png)

![image](https://user-images.githubusercontent.com/116165769/227757307-b8aa64d6-7207-4240-a40b-ad4f803da0c7.png)


<!-- 把解法代码通过所有测试用例的截图粘贴在这里，用来证明代码的正确性 -->