### PR TITLE
[fix][Python] find-k-pairs-with-smallest-sums

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -24470,30 +24470,26 @@ class PriorityQueue {
 ```
 
 ```python
-# by chatGPT (python)
 import heapq
-
 class Solution:
     def kSmallestPairs(self, nums1: List[int], nums2: List[int], k: int) -> List[List[int]]:
-        # 存储三元组 (num1[i], nums2[i], i)
-        # i 记录 nums2 元素的索引位置，用于生成下一个节点
         pq = []
+	# 创建四元组，首个元素须为两个列表第一个元素之和才能被排序
+	# i 记录 nums2 元素的索引位置，用于生成下一个节点
         for i in range(len(nums1)):
-            heapq.heappush(pq, [nums1[i], nums2[0], 0])
-            
+		heapq.heappush(pq, (nums1[i]+nums2[0], nums1[i], nums2[0], 0))
+
         res = []
-        # 执行合并多个有序链表的逻辑
-        while pq and k > 0:
-            cur = heapq.heappop(pq)
-            k -= 1
-            # 链表中的下一个节点加入优先级队列
-            next_index = cur[2] + 1
-            if next_index < len(nums2):
-                heapq.heappush(pq, [cur[0], nums2[next_index], next_index])
-            
-            pair = [cur[0], cur[1]]
-            res.append(pair)
-        
+	# 执行合并多个有序链表的逻辑
+        while k>0 and pq:
+		cur = heapq.heappop(pq)
+		k-=1
+		# 链表中的下一个节点加入优先级队列
+            	newIndex = cur[3]+1
+            	if newIndex < len(nums2):
+                	heapq.heappush(pq, (cur[1]+nums2[newIndex], cur[1], nums2[newIndex], newIndex))
+
+		res.append(list(cur[1:3]))
         return res
 ```
 


### PR DESCRIPTION
ChatGPT生成的解法没有考虑Python里heapq排序的特殊性，这里修复了这个问题，将两元素之和作为元组的首个元素以让整个列表保持有序。

<!-- 
如果你是在修复刷题插件的解法代码，请遵循正确的格式，具体要求参见如下链接：

https://github.com/labuladong/fucking-algorithm/issues/1113
-->

<!-- 如果你的 PR 能够关闭某个 issue，那么在 Fixes 关键词后面输入该 issue 的链接 -->

Fixes #1411 

我修改的是如下题目的Python解法：
https://leetcode.com/problems/find-k-pairs-with-smallest-sums/description/
<!-- 这里放对应题目的链接，方便验证代码 -->

通过截图如下：

<img width="1462" alt="image" src="https://github.com/labuladong/fucking-algorithm/assets/34707116/7d7e5429-f4eb-41bc-846c-1745db686320">

<!-- 把解法代码通过所有测试用例的截图粘贴在这里，用来证明代码的正确性 -->