### PR TITLE
fix: edge case in zuo-xuan-zhuan-zi-fu-chuan-lcof

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -71041,6 +71041,7 @@ public:
 ```go
 // by chatGPT (go)
 func reverseLeftWords(s string, n int) string {
+    if n > len(s) { return s }
     return s[n:] + s[:n]
 }
 ```


### PR DESCRIPTION
Fixes: https://github.com/labuladong/fucking-algorithm/issues/1370

<!-- 
如果你是在修复刷题插件的解法代码，请遵循正确的格式，具体要求参见如下链接：

https://github.com/labuladong/fucking-algorithm/issues/1113
-->


我修改的是如下题目的 xx 解法：

<!-- 这里放对应题目的链接，方便验证代码 -->

通过截图如下：
<img width="1472" alt="Screenshot 2023-07-01 at 9 35 48 pm" src="https://github.com/labuladong/fucking-algorithm/assets/28685065/fd0f1b67-9901-4b7d-858e-e406c6e54de6">


<!-- 把解法代码通过所有测试用例的截图粘贴在这里，用来证明代码的正确性 -->