### PR TITLE
[fix][python]maximum-sum-bst-in-binary-tree

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38150,7 +38150,7 @@ class Solution:
         self.maxSum = 0
     
     def maxSumBST(self, root: TreeNode) -> int:
-        self.traverse(root)
+        self.findMaxMinSum(root)
         return self.maxSum
     
     def findMaxMinSum(self, root: TreeNode) -> List[int]:
@@ -38162,7 +38162,7 @@ class Solution:
         left = self.findMaxMinSum(root.left)
         right = self.findMaxMinSum(root.right)
         
-        /*******后序遍历位置*******/
+        # /*******后序遍历位置*******/
         res = [0] * 4
         # 这个 if 在判断以 root 为根的二叉树是不是 BST
         if left[0] == 1 and right[0] == 1 and root.val > left[2] and root.val < right[1]:
@@ -38180,7 +38180,7 @@ class Solution:
             # 以 root 为根的二叉树不是 BST
             res[0] = 0
             # 其他的值都没必要计算了，因为用不到
-        /**************************/
+        # /**************************/
         return res
 ```
 


### PR DESCRIPTION
<!-- 
如果你是在修复刷题插件的解法代码，请遵循正确的格式，具体要求参见如下链接：

https://github.com/labuladong/fucking-algorithm/issues/1113
-->

<!-- 如果你的 PR 能够关闭某个 issue，那么在 Fixes 关键词后面输入该 issue 的链接 -->

Fixes https://github.com/labuladong/fucking-algorithm/issues/1471

我修改的是如下题目的 xx 解法：
https://leetcode.cn/problems/maximum-sum-bst-in-binary-tree
<!-- 这里放对应题目的链接，方便验证代码 -->

通过截图如下：
<img width="1911" alt="image" src="https://github.com/labuladong/fucking-algorithm/assets/17448639/1d8505a9-84e8-470c-8c96-b8a695199e05">

<!-- 把解法代码通过所有测试用例的截图粘贴在这里，用来证明代码的正确性 -->