### PR TITLE
[fix][golang] merge-two-sorted-lists

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38707,7 +38707,7 @@ public:
 ```
 
 ```go
-// by chatGPT (go)
+// by mario-huang (go)
 /**
  * Definition for singly-linked list.
  * type ListNode struct {

--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38721,6 +38721,9 @@ func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
     p, p1, p2 := dummy, list1, list2
 
     for p1 != nil && p2 != nil {
+        /**<extend down -200>
+        ![](../pictures/链表技巧/1.gif)
+        */
         // 比较 p1 和 p2 两个指针
         // 将值较小的的节点接到 p 指针
         if p1.Val > p2.Val {

--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38715,17 +38715,12 @@ public:
  *     Next *ListNode
  * }
  */
-func mergeTwoLists(l1 *ListNode, l2 *ListNode) *ListNode {
+func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
     // 虚拟头结点
     dummy := &ListNode{-1, nil}
-    p := dummy
-    p1 := l1
-    p2 := l2
+    p, p1, p2 := dummy, list1, list2
 
     for p1 != nil && p2 != nil {
-        /**<extend down -200>
-        ![](../pictures/链表技巧/1.gif)
-        */
         // 比较 p1 和 p2 两个指针
         // 将值较小的的节点接到 p 指针
         if p1.Val > p2.Val {


### PR DESCRIPTION
- Consistent with the function signature on LeetCode
```
func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
    
}
```
- More in line with Go's coding conventions, and also more consistent with the author's solution approach.
```java
// 虚拟头结点
ListNode dummy = new ListNode(-1), p = dummy;
ListNode p1 = l1, p2 = l2;
```
```go
// 虚拟头结点
dummy := &ListNode{-1, nil}
p, p1, p2 := dummy, list1, list2
```

我修改的是如下题目的 golang 解法：
https://leetcode.com/problems/merge-two-sorted-lists

通过截图如下：
<img width="1440" alt="Screenshot 2024-04-06 at 11 25 58 AM" src="https://github.com/labuladong/fucking-algorithm/assets/6395323/58b60356-5eae-4648-ac1b-08ee3e829d51">
