### PR TITLE
[fix][golang] merge-k-sorted-lists

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38377,24 +38377,24 @@ func mergeKLists(lists []*ListNode) *ListNode {
     if len(lists) == 0 {
         return nil
     }
-    // 虚拟头节点
-    dummy := &ListNode{Val: -1}
+    // 虚拟头结点
+    dummy := &ListNode{-1, nil}
     p := dummy
-    // 优先队列,最小堆, 用golang的heap
-    pq := make(Queue, len(lists))
-    for i, head := range lists {
+    // 优先级队列，最小堆，用golang的heap包实现
+    pq := &PriorityQueue{}
+    heap.Init(pq)
+    // 将 k 个链表的头结点加入最小堆
+    for _, head := range lists {
         if head != nil {
-            pq[i] = head
+            heap.Push(pq, head)
         }
     }
-    heap.Init(&pq)
-
-    for pq.Len() != 0 {
+    for pq.Len() > 0 {
         // 获取最小节点，接到结果链表中
-        node := heap.Pop(&pq).(*ListNode)
+        node := heap.Pop(pq).(*ListNode)
         p.Next = node
         if node.Next != nil {
-            heap.Push(&pq, node.Next)
+            heap.Push(pq, node.Next)
         }
         // p 指针不断前进
         p = p.Next
@@ -38402,29 +38402,29 @@ func mergeKLists(lists []*ListNode) *ListNode {
     return dummy.Next
 }
 
-// golang的堆排序Queue
-type Queue []*ListNode
+// golang的堆，需要实现heap.Interface
+type PriorityQueue []*ListNode
 
-func (q Queue) Len() int { return len(q) }
-
-func (q Queue) Less(i, j int) bool {
-    return q[i].Val < q[j].Val
+func (pq PriorityQueue) Len() int {
+    return len(pq)
 }
 
-func (q Queue) Swap(i, j int) {
-    q[i], q[j] = q[j], q[i]
+func (pq PriorityQueue) Less(i int, j int) bool {
+    return pq[i].Val < pq[j].Val
 }
 
-func (q *Queue) Push(x interface{}) {
-    *q = append(*q, x.(*ListNode))
+func (pq PriorityQueue) Swap(i int, j int) {
+    pq[i], pq[j] = pq[j], pq[i]
 }
 
-func (q *Queue) Pop() interface{} {
-    old := *q
-    n := len(old)
-    x := old[n-1]
-    *q = old[:n-1]
-    return x
+func (pq *PriorityQueue) Push(x any) {
+    *pq = append(*pq, x.(*ListNode))
+}
+
+func (pq *PriorityQueue) Pop() any {
+    node := (*pq)[len(*pq)-1]
+    *pq = (*pq)[:len(*pq)-1]
+    return node
 }
 ```
 

--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -38370,9 +38370,14 @@ private:
 ```
 
 ```go
-// by chatGPT (go)
-//Definition for singly-linked list.
-
+// by mario-huang (go)
+/**
+ * Definition for singly-linked list.
+ * type ListNode struct {
+ *     Val int
+ *     Next *ListNode
+ * }
+ */
 func mergeKLists(lists []*ListNode) *ListNode {
     if len(lists) == 0 {
         return nil


### PR DESCRIPTION
- Define the `pq` variable as a pointer to simplify the syntax and make it easier for the reader to understand. 
- Replace `interface{}` with `any`, although they are equivalent, using `any` keeps the code consistent with the go's tool `generate interface stubs`.
- Simplify the pop node expression for better understanding.
- Rename Queue to PriorityQueue to avoid conceptual confusion. Queue is commonly used to represent a first-in-first-out (FIFO) queue, while PriorityQueue is commonly used to represent a heap.

我修改的是如下题目的 golang 解法：
https://leetcode.com/problems/merge-k-sorted-lists

通过截图如下：
<img width="1440" alt="Screenshot 2024-04-06 at 12 02 32 PM" src="https://github.com/labuladong/fucking-algorithm/assets/6395323/b9a8a5cf-b018-4f26-b8a6-1ed94ccf0257">
