### PR TITLE
[fix][golang] diameter-of-binary-tree

### DIFF
--- a/多语言解法代码/solution_code.md
+++ b/多语言解法代码/solution_code.md
@@ -19535,36 +19535,27 @@ public:
 ```
 
 ```go
-// by chatGPT (go)
 func diameterOfBinaryTree(root *TreeNode) int {
-    maxDiameter := 0
-    maxDepth := func(root *TreeNode) int {
-        if root == nil {
-            return 0
-        }
-        leftMax := maxDepth(root.Left)
-        rightMax := maxDepth(root.Right)
-        // 后序遍历位置顺便计算最大直径
-        maxDiameter = max(maxDiameter, leftMax+rightMax)
-        return 1 + max(leftMax, rightMax)
-    }
-    maxDepth(root)
-    return maxDiameter
+	maxDiameter := 0
+	maxDepth(root, &maxDiameter)
+	return maxDiameter
+}
+
+func maxDepth(node *TreeNode, maxDiameter *int) int {
+	if node == nil {
+		return 0
+	}
+	leftMax := maxDepth(node.Left, maxDiameter)
+	rightMax := maxDepth(node.Right, maxDiameter)
+	// Calculate the diameter
+	*maxDiameter = max(*maxDiameter, leftMax+rightMax)
+	return 1 + max(leftMax, rightMax)
 }
 
 // 这是一种简单粗暴，但是效率不高的解法
 func diameterOfBinaryTree(root *TreeNode) int {
     if root == nil {
         return 0
-    }
-    // 计算出左右子树的最大高度
-    maxDepth := func(root *TreeNode) int {
-        if root == nil {
-            return 0
-        }
-        leftMax := maxDepth(root.Left)
-        rightMax := maxDepth(root.Right)
-        return 1 + max(leftMax, rightMax)
     }
     leftMax := maxDepth(root.Left)
     rightMax := maxDepth(root.Right)
@@ -19574,6 +19565,15 @@ func diameterOfBinaryTree(root *TreeNode) int {
     return max(res,
         max(diameterOfBinaryTree(root.Left),
             diameterOfBinaryTree(root.Right)))
+}
+
+func maxDepth(node *TreeNode) int {
+    if node == nil {
+        return 0
+    }
+    leftMax := maxDepth(node.Left)
+    rightMax := maxDepth(node.Right)
+    return 1 + max(leftMax, rightMax)
 }
 
 func max(a, b int) int {


### PR DESCRIPTION
Fixes #1134 
我修改的是如下题目的 golang 解法：
https://leetcode.cn/problems/diameter-of-binary-tree/
通过截图如下：
<img width="1409" alt="diameter-of-binary-tree-1" src="https://github.com/labuladong/fucking-algorithm/assets/39549743/d01908cb-6d01-4782-86af-2b8fc5224c0e">
<img width="1410" alt="diameter-of-binary-tree-2" src="https://github.com/labuladong/fucking-algorithm/assets/39549743/7cfc5f2a-47cf-4491-b8b9-0aa21c1879c1">