### PR TITLE
Clarify hash table collision strategies with complexity

### DIFF
--- a/think_like_computer/Framework and thoughts about learning data structure and algorithm.md
+++ b/think_like_computer/Framework and thoughts about learning data structure and algorithm.md
@@ -22,7 +22,10 @@ For example, 「queue」 and 「stack」 data structures can be implemented with
 
 A graph can be implemented with both linked lists and arrays. An adjacency table is a linked list, and an adjacency matrix is a two-dimensional array. An adjacency matrix can be used to evaluate connectivity quickly and can solve some problems via matrix operations, but if the graph is sparse, this becomes very time-consuming. An adjacency table is more space-saving, but the efficiency of many operations is certainly less than for an adjacency matrix.
 
-Hashtables map keys to a large array by making use of a hash function to solve hash conflicts. Chaining needs linked list features with simple operations, but with the extra space needed to store pointers; linear exploration methods need array features, to address continuously, and does not need the extra storage space for pointers, but the operation is slightly more complex.
+Hash tables use a hash function to map keys to array indices. When collisions occur, there are two common strategies:
+
+- **Chaining (linked list):** Each array slot holds a linked list of colliding entries. Insertion is O(1), lookup/deletion is O(n) worst case if many collisions. Uses extra space for pointers.
+- **Linear probing (array):** Colliding entries go into the next available slot. More cache-friendly and no pointer overhead, but deletion requires tombstones to maintain probe sequences.
 
 The implementation of trees with arrays is a "heap", because a "heap" is a complete binary tree. Heap storage with arrays does not need node pointers and the operation is relatively simple; the implementation with linked list is a very common kind of "tree", because it is not necessarily a complete binary tree, so it is not suitable to use array storage. For this reason, based on the tree structure of the list, various ingenious designs have been derived, such as binary search trees (BST), AVL trees, red-black trees, interval trees, B-trees, etc., to deal with different problems.
 


### PR DESCRIPTION
Addresses feedback from #2609.

The hash table explanation was confusing and used vague language like "slightly more complex." Rewrote with clear bullet points explaining:

- **Chaining:** O(1) insertion, O(n) worst-case lookup, extra pointer space
- **Linear probing:** Cache-friendly, no pointer overhead, but deletion requires tombstones

**Before:**
> Hashtables map keys to a large array by making use of a hash function to solve hash conflicts. Chaining needs linked list features with simple operations, but with the extra space needed to store pointers; linear exploration methods need array features, to address continuously, and does not need the extra storage space for pointers, but the operation is slightly more complex.

**After:**
> Hash tables use a hash function to map keys to array indices. When collisions occur, there are two common strategies:
> - **Chaining (linked list):** Each array slot holds a linked list of colliding entries. Insertion is O(1), lookup/deletion is O(n) worst case if many collisions. Uses extra space for pointers.
> - **Linear probing (array):** Colliding entries go into the next available slot. More cache-friendly and no pointer overhead, but deletion requires tombstones to maintain probe sequences.